### PR TITLE
Changed from runsvdir-start to runsvdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q runit
 RUN mkdir -p /etc/service/your_app/
 COPY ./your_app/run /etc/service/your_app/run
 
-ENTRYPOINT ["/usr/sbin/runsvdir-start", "-P /etc/service"]
+ENTRYPOINT ["runsvdir",  "-P", "/etc/service"]


### PR DESCRIPTION
This PR does what's suggested [here](http://disq.us/p/18xc7mi) and replaces the `runsvdir-start` command with `runsvdir`, so the environment variable "hack" is made unnecessary.